### PR TITLE
Fix required is not defined err

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,10 @@ var showToaster = function(currentWindow, msg) {
 		frame: false,
 		show : false,
 		"skip-taskbar": true,
-		"always-on-top": true
+		"always-on-top": true,
+		webPreferences: {
+			nodeIntegration: true
+		}
 	});
 
 


### PR DESCRIPTION
Following error occurred when using electron version bigger than 5.0.0.
> `require is not defined`

To fix this bug, you should set `nodeIntegration` field true.

### Reference
> https://stackoverflow.com/questions/55093700/electron-5-0-0-uncaught-referenceerror-require-is-not-defined